### PR TITLE
Fix broken link in pug index file

### DIFF
--- a/node/views/index.pug
+++ b/node/views/index.pug
@@ -17,7 +17,7 @@ block content
 
                 iframe(src="http://localhost:3000/public/dashboard/e104be98-2ea1-4dce-abff-aa3cfeddfe40" frameborder="0" width="800" height="600" allowtransparency)
 
-                p Similarly, we can embed a a(href="http://localhost:3000/public/question/938a446c-da62-479a-a1bd-913cd29a77ef")single question's chart in our application as below. 
+                p Similarly, we can embed a <a href="http://localhost:3000/public/question/938a446c-da62-479a-a1bd-913cd29a77ef">single question's chart</a> in our application as below. 
 
                 iframe(src="http://localhost:3000/public/question/938a446c-da62-479a-a1bd-913cd29a77ef" frameborder="0"               width="800" height="600" allowtransparency)
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- fixes broken link for "single question's chart" in `index.pug`

### How should this be manually tested
- build and set up metabase
- run node app
- visit http://localhost:3001/#public
- link should be working normally 