### PR TITLE
Two simpler embedding examples.

### DIFF
--- a/django/single_question/about.html
+++ b/django/single_question/about.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>About {{ title }}</title>
+  </head>
+  <body>
+    <h1>About {{ title }}</h1>
+    <p>Developed by {{ author }}.</p>
+    <p><a href="{% url 'homepage' %}">Go home</a>.</p>
+    <p>See <a href="https://simpleisbetterthancomplex.com/article/2017/08/07/a-minimal-django-application.html">this article by Vitor Freitas</a> for inspiration.</p>
+  </body>
+</html>

--- a/django/single_question/embed.html
+++ b/django/single_question/embed.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title }}</title>
+</head>
+<body>
+  <h1>Embed {{ title }}</h1>
+  <iframe
+    src="{{iframeUrl}}"
+    frameborder="1"
+    width="800"
+    height="600"
+  ></iframe>
+</body>
+</html>

--- a/django/single_question/index.py
+++ b/django/single_question/index.py
@@ -1,0 +1,69 @@
+# A minimal example of a signed embedding in a Django application. Run this program with:
+#
+#    django-admin runserver --pythonpath=. --settings=mbdj
+#
+# URLs are:
+# - http://localhost:8000/       : home page
+# - http://localhost:8000/about/ : some information
+# - http://localhost:8000/embed/ : embedding a single question
+#
+# You will need to modify the value of `METABASE_SECRET_KEY` to make this work.
+# Please see https://www.metabase.com/learn/developing-applications/advanced-metabase/embedding-charts-and-dashboards.html
+# for the full tutorial.
+
+import os
+import time
+
+from django.conf.urls import url
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+
+import jwt
+
+
+DEBUG = True
+SECRET_KEY = '4l0ngs3cr3tstr1ngw3lln0ts0l0ngw41tn0w1tsl0ng3n0ugh'
+ROOT_URLCONF = __name__
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.getcwd()]
+    }
+]
+
+METABASE_SITE_URL = 'http://localhost:3000'
+METABASE_SECRET_KEY = '40e0106db5156325d600c37a5e077f44a49be1db9d02c96271e7bd67cc9529fa'
+
+
+def home(request):
+    return HttpResponse('<h1>Metabase Django embedding example</h1>')
+
+
+def about(request):
+    html = render_to_string('about.html', {
+        'title': 'Embedding Metabase',
+        'author': 'Greg Wilson'
+    })
+    return HttpResponse(html)
+
+
+def embed(request):
+    payload = {
+        'resource': {'question': 1},
+        'params': {},
+        'exp': round(time.time()) + (60 * 10)
+    }
+    token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm='HS256')
+    iframeUrl = METABASE_SITE_URL + '/embed/question/' + token + '#bordered=true&titled=true'
+    html = render_to_string('embed.html', {
+        'title': 'Embedding Metabase',
+        'iframeUrl': iframeUrl
+    })
+    return HttpResponse(html)
+    
+
+urlpatterns = [
+    url(r'^$', home, name='homepage'),
+    url(r'^about/$', about, name='aboutpage'),
+    url(r'^embed/$', embed, name='embedpage')
+]

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,23 @@
+<!--
+A simple example showing how to embed a question using an iframe.  This embed is not signed; please see:
+
+    https://www.metabase.com/learn/developing-applications/advanced-metabase/embedding-charts-and-dashboards.html
+
+for the full tutorial.
+
+You will need to modify the `src` attribute of the iframe to match your Metabase installation.
+-->
+<html>
+  <head>
+    <title>Metabase Embedding</title>
+  </head>
+  <body>
+    <h1>Metabase Embedding</h1>
+    <iframe
+      src="http://localhost:3000/public/question/7f0c3c4b-173e-452c-810f-ccb3fc4482a3"
+      frameborder="1"
+      width="600"
+      height="400"
+      ></iframe>
+  </body>
+</html>


### PR DESCRIPTION
1.  `html/index.html` shows how to embed an unsigned iframe.
2.  `django/single_question/*` shows how to embed a single signed question.