### PR TITLE
Fix for Django urls import after Django 3.0

### DIFF
--- a/django/minimal_example/index.py
+++ b/django/minimal_example/index.py
@@ -12,7 +12,7 @@
 import os
 import time
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 
@@ -47,5 +47,5 @@ def home(request):
     
 
 urlpatterns = [
-    url(r'^$', home, name='homepage')
+    re_path(r'^$', home, name='homepage')
 ]


### PR DESCRIPTION
django.conf.urls is deprecated after Django 3.0, re_path can be used instead.       
Reference: https://stackoverflow.com/questions/70319606/importerror-cannot-import-name-url-from-django-conf-urls-after-upgrading-to